### PR TITLE
fix: 修复在vue2.7.16版本拖动后滑块固定在右边失效问题

### DIFF
--- a/src/dragVerify.vue
+++ b/src/dragVerify.vue
@@ -134,9 +134,11 @@
             	var handler = this.$refs.handler;
                 if(_x > 0 && _x <= (this.width-this.height)){
                     handler.style.left = _x + 'px';
+					this.$set(this.handlerStyle, "left", handler.style.left);
                     this.$refs.progressBar.style.width = (_x+this.height/2)+'px';
                 }else if(_x > (this.width-this.height)){  
                 	handler.style.left = (this.width - this.height)+ 'px';
+					this.$set(this.handlerStyle, "left", handler.style.left);
                     this.$refs.progressBar.style.width = (this.width-this.height/2)+'px';
                      this.passVerify();
                 }


### PR DESCRIPTION
在最新的vuevue2.7.16版本中使用该组件时，拖动到最右边后小滑块又跳回left=“0px”位置